### PR TITLE
Add job_settings parameter to REST API for submitting application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN wget https://s3-eu-west-1.amazonaws.com/zalando-spark/${SPARK_PACKAGE}.tgz -
  && chmod -R 777 $SPARK_DIR \
  && mv $SPARK_DIR/conf/core-site.xml.zalando $SPARK_DIR/conf/core-site.xml \
  && mv $SPARK_DIR/conf/emrfs-default.xml.zalando $SPARK_DIR/conf/emrfs-default.xml \
+ && mv $SPARK_DIR/conf/spark-defaults.conf.zalando $SPARK_DIR/conf/spark-defaults.conf \
  && mv $SPARK_DIR/conf/spark-env.sh.zalando $SPARK_DIR/conf/spark-env.sh \
  && mkdir /tmp/s3 && chmod -R 777 /tmp
 

--- a/examples/python/SparkTextFile_RW_Test.py
+++ b/examples/python/SparkTextFile_RW_Test.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+
+import sys
+from operator import add
+
+from pyspark import SparkContext
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: wordcount <input_file> [output_dir]", file=sys.stderr)
+        exit(-1)
+    sc = SparkContext(appName="PythonWordCount")
+    lines = sc.textFile(sys.argv[1], 1)
+    counts = lines.flatMap(lambda x: x.split(' ')) \
+                  .map(lambda x: (x, 1)) \
+                  .reduceByKey(add)
+    output = counts.collect()
+    for (word, count) in output:
+        print("%s: %i" % (word, count))
+    if len(sys.argv) > 2:
+        print("Saving wordcount results to " + sys.argv[2])
+        counts.saveAsTextFile(sys.argv[2])
+    sc.stop()

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -83,6 +83,12 @@ paths:
           in: formData
           type: string
           required: false
+        - job_settings:
+          name: job_settings
+          description: Spark settings (whitespace-separated) for Spark App Jar or Python script
+          in: formData
+          type: string
+          required: false
       responses:
         200:
           description: Successful


### PR DESCRIPTION
users can send settings for spark application now:

```
wget https://raw.githubusercontent.com/zalando/spark-appliance/master/examples/python/SparkTextFile_RW_Test.py

oauth_token=xxxxxxx-xxx-xxxxxx
host=spark-master.teamid.example.org

curl --insecure --request POST --header "Authorization: Bearer $oauth_token" \
    -F file=@SparkTextFile_RW_Test.py \
    -F "job_settings=--executor-memory 2G --total-executor-cores 2" \
    -F "job_args=s3://zalando-bi-tmp-eu-west-1/links.txt s3://zalando-bi-tmp-eu-west-1/mapped_result" \
    https://$host/submit_application
```