### PR TITLE
Add hivevar hiveconf username password as parameter for sending SQL query

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -53,6 +53,30 @@ paths:
           in: body
           type: string
           required: true
+        - hive_vars:
+          name: hive_vars
+          description: whitespace-separated list of --hivevar parameters
+          in: formData
+          type: string
+          required: false
+        - hive_confs:
+          name: hive_confs
+          description: whitespace-separated list of --hiveconf parameters
+          in: formData
+          type: string
+          required: false
+        - username:
+          name: username
+          description: username to login
+          in: formData
+          type: string
+          required: false
+        - password:
+          name: password
+          description: password to login
+          in: formData
+          type: string
+          required: false
       responses:
         200:
           description: Successful


### PR DESCRIPTION
Assume you have a Spark SQL query ```count_with_var.sql``` like this:

```
use ${database};
select count(*) from some_table
where created_date > '${work_date}';
```

you need to set hive variables ```database=some_db_name``` and ```work_date=2015-10-15```

with this PR, you can send these parameters by HTTP call:

```
oauth_token=xxx-xxxxxxx-xxxxx
host=spark-webapp.teamid.example.org

curl --insecure --request POST \
     --header "Authorization: Bearer $oauth_token" \
     -F file=@count_with_var.sql \
     -F hive_vars="database=some_db_name work_date=2015-10-15" \
     https://$host/send_query
```

you may also want to set some hive configs, like ```spark.sql.hive.metastorePartitionPruning=true```, even give a username and password to send your query to spark thrift server (you can set extra user authentication in hive-site.xml for your spark thrift server)

then your HTTP call will look like:

```
oauth_token=xxx-xxxxxxx-xxxxx
host=spark-webapp.teamid.example.org

curl --insecure --request POST \
     --header "Authorization: Bearer $oauth_token" \
     -F file=@count_with_var.sql \
     -F hive_vars="database=some_db_name work_date=2015-10-15" \
     -F hive_confs="spark.sql.hive.metastorePartitionPruning=true" \
     -F username=your_user_name -F password="some_password" \
     https://$host/send_query
```
