### PR TITLE
Add document for integrating with Ro2Key to deploy Spark programmatically

### DIFF
--- a/senza_create_with_ro2key/README.md
+++ b/senza_create_with_ro2key/README.md
@@ -1,0 +1,63 @@
+```
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+aws iam create-role --role-name senza-create-spark --assume-role-policy-document file://$DIR/policy_trust.json
+aws iam put-role-policy --role-name senza-create-spark --policy-name MintBucketAndSenzaCreate --policy-document file://$DIR/policy_senza_create.json
+aws iam put-role-policy --role-name senza-create-spark --policy-name AssumeRoleByItSelf --policy-document file://$DIR/policy_assumerole.json
+```
+
+
+```
+senza create https://raw.githubusercontent.com/zalando/ro2key/master/ro2key.yaml senzacreatespark \
+             DockerImage=pierone.example.org/teamid/ro2key:0.3-SNAPSHOT \
+             ApplicationID=teamid-ro2key \
+             MintBucket=zalando-stups-mint-123456789-eu-west-1 \
+             ScalyrAccountKey=xxxxxx-xxxx-xxxx-xxx \
+             RolesArnPrefix="arn:aws:iam::123456789:role" \
+             TargetRole=senza-create-spark \
+             AuthURL="https://token.auth.example.org/access_token" \
+             TokenInfoURL="https://auth.example.org/oauth2/tokeninfo" \
+             Oauth2Scope="scope_for_ro2key" \
+             HostedZone="teamid.example.org." \
+             SSLCertificateId="arn:aws:iam::123456789:server-certificate/your_ssl_cert"
+```
+
+
+```
+AWS_ACCESS_KEY_ID=id_of_mint_bucket_readonly_user AWS_SECRET_ACCESS_KEY=secret_key_of_mint_bucket_readonly_user AWS_SESSION_TOKEN="" aws s3 cp --region eu-west-1 s3://zalando-stups-mint-123456789-eu-west-1/teamid-ro2key/client.json .
+AWS_ACCESS_KEY_ID=id_of_mint_bucket_readonly_user AWS_SECRET_ACCESS_KEY=secret_key_of_mint_bucket_readonly_user AWS_SESSION_TOKEN="" aws s3 cp --region eu-west-1 s3://zalando-stups-mint-123456789-eu-west-1/teamid-ro2key/user.json .
+
+application_username=$(jq -r .application_username user.json)
+application_password=$(jq -r .application_password user.json)
+client_id=$(jq -r .client_id client.json)
+client_secret=$(jq -r .client_secret client.json)
+
+encoded_scopes="scope_for_ro2key"
+
+encoded_application_password=$(python3 -c "import urllib.parse; print(urllib.parse.quote_plus('$application_password'))")
+
+access_token=$(curl -u "$client_id:$client_secret" --silent -d "grant_type=password&username=$application_username&password=$encoded_application_password&scope=$encoded_scopes" https://auth.example.org/oauth2/access_token\?realm\=/services | jq -r .access_token)
+
+key=$(curl -s --insecure --request GET --header "Authorization: Bearer $access_token" https://ro2key-senzacreatespark.example.org/get_key/senza-create-spark)
+export AWS_ACCESS_KEY_ID=$(echo $key | jq .AccessKeyId -r)
+export AWS_SECRET_ACCESS_KEY=$(echo $key | jq .SecretAccessKey -r)
+export AWS_SESSION_TOKEN=$(echo $key | jq .SessionToken -r)
+export AWS_DEFAULT_REGION="eu-west-1"
+
+senza create https://raw.githubusercontent.com/zalando/spark-appliance/master/spark.yaml one \
+             DockerImage=pierone.example.org/teamid/spark:1.5.3-SNAPSHOT \
+             ApplicationID=teamid-spark \
+             MintBucket=zalando-stups-mint-123456789-eu-west-1 \
+             ScalyrAccountKey=xxxxxx-xxxx-xxxx-xxx \
+             StartMaster=true \
+             StartWorker=true \
+             StartThriftServer=true \
+             StartWebApp=true \
+             HiveSite="s3://some-bucket-eu-west-1/hive-config/hive-site-mysql.xml" \
+             ExtJars="s3://some-bucket-tmp-eu-west-1/libs/super-csv-2.2.0.jar" \
+             AuthURL="https://token.auth.example.org/access_token" \
+             TokenInfoURL="https://auth.example.org/oauth2/tokeninfo" \
+             Oauth2Scope="scope_for_spark" \
+             HostedZone="teamid.example.org." \
+             SSLCertificateId="arn:aws:iam::123456789:server-certificate/your_ssl_cert" \
+             InstanceType=m4.xlarge ExecutorMemory=12g
+```

--- a/senza_create_with_ro2key/README.md
+++ b/senza_create_with_ro2key/README.md
@@ -1,3 +1,6 @@
+To enable robot user to create spark cluster with ```senza create```, we need to deploy a [Ro2Key](https://github.com/zalando/ro2key) application with an  ```IAM-role``` with permissions for senza-create.
+
+Use following script to create this ```IAM-role``` with name ```senza-create-spark```, change the IDs (AWS account ID, etc.) to yours.
 ```
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 aws iam create-role --role-name senza-create-spark --assume-role-policy-document file://$DIR/policy_trust.json
@@ -5,7 +8,7 @@ aws iam put-role-policy --role-name senza-create-spark --policy-name MintBucketA
 aws iam put-role-policy --role-name senza-create-spark --policy-name AssumeRoleByItSelf --policy-document file://$DIR/policy_assumerole.json
 ```
 
-
+Then we need to deploy ro2key manually, after login with [mai](https://stups.io/mai), use following command:
 ```
 senza create https://raw.githubusercontent.com/zalando/ro2key/master/ro2key.yaml senzacreatespark \
              DockerImage=pierone.example.org/teamid/ro2key:0.3-SNAPSHOT \
@@ -21,7 +24,9 @@ senza create https://raw.githubusercontent.com/zalando/ro2key/master/ro2key.yaml
              SSLCertificateId="arn:aws:iam::123456789:server-certificate/your_ssl_cert"
 ```
 
+Now you can use following script to deploy Spark cluster programmatically by robot user.
 
+(If your legacy system do not configured [berry](https://stups.io/berry) daemon, you can create a IAM-user in your AWS account with a IAM-policy of read-only permission on the ```mint bucket folder of ro2key```, then use its AWS credential to get the JSON files of application)
 ```
 AWS_ACCESS_KEY_ID=id_of_mint_bucket_readonly_user AWS_SECRET_ACCESS_KEY=secret_key_of_mint_bucket_readonly_user AWS_SESSION_TOKEN="" aws s3 cp --region eu-west-1 s3://zalando-stups-mint-123456789-eu-west-1/teamid-ro2key/client.json .
 AWS_ACCESS_KEY_ID=id_of_mint_bucket_readonly_user AWS_SECRET_ACCESS_KEY=secret_key_of_mint_bucket_readonly_user AWS_SESSION_TOKEN="" aws s3 cp --region eu-west-1 s3://zalando-stups-mint-123456789-eu-west-1/teamid-ro2key/user.json .

--- a/senza_create_with_ro2key/policy_assumerole.json
+++ b/senza_create_with_ro2key/policy_assumerole.json
@@ -1,0 +1,14 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::123456789:role/senza-create-spark"
+            ]
+        }
+    ]
+}

--- a/senza_create_with_ro2key/policy_senza_create.json
+++ b/senza_create_with_ro2key/policy_senza_create.json
@@ -1,0 +1,24 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowMintRead",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::zalando-stups-mint-123456789-eu-west-1/teamid-ro2key/*"
+        },
+        {
+            "Sid": "SenzaCreate",
+            "Resource": "*",
+            "Effect": "Allow",
+            "Action": [
+                "iam:*",
+                "cloudformation:*",
+                "ec2:*",
+                "route53:*",
+                "elasticloadbalancing:*",
+                "autoscaling:*"
+            ]
+        }
+    ]
+}

--- a/senza_create_with_ro2key/policy_trust.json
+++ b/senza_create_with_ro2key/policy_trust.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/spark.yaml
+++ b/spark.yaml
@@ -6,7 +6,7 @@ SenzaInfo:
     - ApplicationID:
         Description: "The application ID according to Yourturn/Kio"
     - MintBucket:
-        Description: "Mint Bucket of buku."
+        Description: "Mint Bucket of Spark application"
     - ScalyrKey:
         Description: "The API key of Scalyr logging service used by Taupage"
         Default: ""
@@ -56,7 +56,7 @@ SenzaInfo:
         Description: "OAuth2 scope to access the WebApp"
         Default: "uid"
     - HostedZone:
-        Description: "Hosted Zone in which Stups deploys"
+        Description: "Hosted Zone in which STUPS deploys"
         Default: ""
     - SSLCertificateId:
         Description: "ARN of your SSL Certificate which will be used for ELB"


### PR DESCRIPTION
should only be used for robot user, such as cron job from a common user

human user is able to access any AWS resources with ssh-tunnel via [odd](https://stups.io/odd) server created by [piu](https://stups.io/piu) (for accessing STUPS applications), or with AWS credential created by [mai](https://stups.io/mai) (for creating senza applications or accessing s3 files).