### PR TITLE
Support non-STUPS environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ Note that if you do not need the [thrift server](https://spark.apache.org/docs/1
 ### Running with Docker locally
 
 ```
-docker build -t registry.opensource.zalan.do/bi/spark:1.6.2-1 .
+docker build -t registry.opensource.zalan.do/bi/spark:1.6.2-2 .
 
 docker run -d --net=host \
            -e START_MASTER="true" \
            -e START_WORKER="true" \
            -e START_WEBAPP="true" \
            -e START_NOTEBOOK="true" \
-           registry.opensource.zalan.do/bi/spark:1.6.2-1
+           registry.opensource.zalan.do/bi/spark:1.6.2-2
 ```
 
 After that, you can check if the spark master is running:
@@ -99,7 +99,7 @@ And try the Jupyter Notebook with URL ```http://localhost:8888/```
 
 ```
 senza create spark.yaml singlenode \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              StartMaster=true \
              StartWorker=true \
              StartThriftServer=true \
@@ -113,7 +113,7 @@ To enable OAuth2 you need to specify ```AuthURL``` and ```TokenInfoURL```.
 
 ```
 senza create spark.yaml master \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              StartMaster=true \
              StartWebApp=true
 ```
@@ -122,7 +122,7 @@ then wait until ```senza list spark``` shows that CloudFormation stack ```spark-
 
 ```
 senza create spark.yaml worker \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              MasterStackName="spark-master" \
              StartWorker=true \
              ClusterSize=3
@@ -134,7 +134,7 @@ You can run a ```WebApp``` node separately with following senza command:
 
 ```
 senza create spark.yaml webapp \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              MasterStackName="spark-master" \
              StartWebApp=true
 ```
@@ -158,7 +158,7 @@ senza create https://raw.githubusercontent.com/zalando/exhibitor-appliance/maste
 After the deployment finished, you will have a CloudFormation stack ```exhibitor-spark```, use this as ```ZookeeperStackName```, you can create a HA Spark cluster:
 ```
 senza create spark.yaml ha \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              ScalyrKey=XXXYYYZZZ \
              StartMaster=true \
              StartWorker=true \
@@ -174,7 +174,7 @@ This senza create command with ```StartMaster=true``` and ```StartWorker=true```
 First, create spark master + webapp stack:
 ```
 senza create spark.yaml master \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              StartMaster=true \
              StartWebApp=true \
              ClusterSize=3 \
@@ -185,7 +185,7 @@ senza create spark.yaml master \
 Wait until CloudFormation stack ```spark-master``` completely deployed, then create workers:
 ```
 senza create spark.yaml worker \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              StartWorker=true \
              ClusterSize=5 \
              ZookeeperStackName="exhibitor-spark" \
@@ -201,7 +201,7 @@ Currently the spark appliance support MySQL or PostgreSQL database as hive metas
 Once you created ```hive-site.xml```, you can pack it into your own docker image, and push this docker image into PierOne repo. Or you upload this hive-site.xml to S3, and use ```HiveSite``` parameter by senza create, such as:
 ```
 senza create spark.yaml singlenode \
-             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-1 \
+             DockerImage=registry.opensource.zalan.do/bi/spark:1.6.2-2 \
              StartMaster=true \
              StartWorker=true \
              StartWebApp=true \

--- a/utils.py
+++ b/utils.py
@@ -134,14 +134,18 @@ def get_alive_master_ip():
             zk.stop()
         return master_ip
     elif master_stack_name != "" and region is not None:
-        elb = boto3.client('elb', region_name=region)
-        ec2 = boto3.client('ec2', region_name=region)
-        master_ips = get_instance_ips(elb, ec2, master_stack_name)
-        if len(master_ips) != 1:
+        try:
+            elb = boto3.client('elb', region_name=region)
+            ec2 = boto3.client('ec2', region_name=region)
+            master_ips = get_instance_ips(elb, ec2, master_stack_name)
+            if len(master_ips) != 1:
+                return ""  # shouldn't happen without zookeeper
+            elif len(master_ips) == 1:
+                return master_ips[0]
+            else:
+                return ""
+        except:
             return ""
-        else:
-            for ip in master_ips:
-                return ip
     else:
         return ""
 


### PR DESCRIPTION
If instance is running in a non-STUPS environment on AWS, it can not get current alive master ip using AWS SDK, it will either return an empty master_ips array from get_instance_ips (```len(master_ips) == 0```) or throw exceptions (handled by try-except block).