### PR TITLE
use the OS pierone registry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+examples*
+LICENCE
+MAINTAINERS
+README.md
+spark.yaml
+tox.ini
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM zalando/python:3.4.0-4
+FROM registry.opensource.zalan.do/stups/python:3.4.0-4
 MAINTAINER Teng Qiu <teng.qiu@zalando.de>
 
 ENV SPARK_VERSION="1.6.2-SNAPSHOT" HADOOP_VERSION="2.6.0"


### PR DESCRIPTION
the docker base images from zalando in the public docker hub will be deleted today. we have to use now the ones from the open source pierone registry.

i checked that build works, but i didn't check functionality!