### PR TITLE
Enhancements for running locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN wget https://s3-eu-west-1.amazonaws.com/zalando-spark/${SPARK_PACKAGE}.tgz -
  && rm -rf /tmp/${SPARK_PACKAGE}.tgz \
  && chmod -R 777 $SPARK_DIR
 
-### CONFIGURING spark and hadoop, ALWAYS NEEDED
-RUN mv $SPARK_DIR/conf/core-site.xml.zalando $SPARK_DIR/conf/core-site.xml \
- && mv $SPARK_DIR/conf/emrfs-default.xml.zalando $SPARK_DIR/conf/emrfs-default.xml \
+### CONFIGURING spark and hadoop, ALWAYS NEEDED - this core-site allows filesystem based credentials as well as EC2 env
+ADD core-site.xml $SPARK_DIR/conf/
+RUN mv $SPARK_DIR/conf/emrfs-default.xml.zalando $SPARK_DIR/conf/emrfs-default.xml \
  && mv $SPARK_DIR/conf/spark-defaults.conf.zalando $SPARK_DIR/conf/spark-defaults.conf \
  && mv $SPARK_DIR/conf/spark-env.sh.zalando $SPARK_DIR/conf/spark-env.sh \
  && mkdir /tmp/s3 && mkdir /tmp/spark-events && chmod -R 777 /tmp

--- a/core-site.xml
+++ b/core-site.xml
@@ -12,10 +12,6 @@
         <value>com.amazon.ws.emr.hadoop.fs.EmrFileSystem</value>
     </property>
     <property>
-        <name>fs.s3n.endpoint</name>
-        <value>s3-eu-west-1.amazonaws.com</value>
-    </property>
-    <property>
         <name>fs.s3.buckets.create.region</name>
         <value>eu-west-1</value>
     </property>

--- a/core-site.xml
+++ b/core-site.xml
@@ -1,0 +1,36 @@
+<configuration>
+    <property>
+        <name>fs.s3.buffer.dir</name>
+        <value>/tmp/s3</value>
+    </property>
+    <property>
+        <name>fs.s3.impl</name>
+        <value>com.amazon.ws.emr.hadoop.fs.EmrFileSystem</value>
+    </property>
+    <property>
+        <name>fs.s3n.impl</name>
+        <value>com.amazon.ws.emr.hadoop.fs.EmrFileSystem</value>
+    </property>
+    <property>
+        <name>fs.s3n.endpoint</name>
+        <value>s3-eu-west-1.amazonaws.com</value>
+    </property>
+    <property>
+        <name>fs.s3.buckets.create.region</name>
+        <value>eu-west-1</value>
+    </property>
+    <property>
+        <name>fs.s3.customAWSCredentialsProvider</name>
+        <value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value>
+        <description>
+            Try and get credentials from the filesystem or environment variables if not on EC2
+        </description>
+    </property>
+    <property>
+        <name>fs.s3n.customAWSCredentialsProvider</name>
+        <value>com.amazonaws.auth.DefaultAWSCredentialsProviderChain</value>
+        <description>
+            Try and get credentials from the filesystem or environment variables if not on EC2
+        </description>
+    </property>
+</configuration>

--- a/utils.py
+++ b/utils.py
@@ -5,7 +5,11 @@ import boto3
 import requests
 import socket
 
-hostip = socket.gethostbyname(socket.gethostname())
+try:
+    hostip = socket.gethostbyname(socket.gethostname())
+except:
+    hostip = "127.0.0.1"
+
 instanceId = hostip
 private_ip = hostip
 region = None

--- a/utils.py
+++ b/utils.py
@@ -3,9 +3,11 @@
 import os
 import boto3
 import requests
+import socket
 
-instanceId = "127.0.0.1"
-private_ip = "127.0.0.1"
+hostip = socket.gethostbyname(socket.gethostname())
+instanceId = hostip
+private_ip = hostip
 region = None
 
 


### PR DESCRIPTION
This change is to allow the following functionality:

 * Add support for s3 credentials from filesystem while running locally - Use of the default credentials provider which cycles through all sources of credentials rather than only using ec2 environment
 * Use host ip while running locally to allow external services to connect i.e. zeppelin notebook

I have tested these locally and have't run into any problems, although i have not confirmed functioning with existing jupyter notebook. Since the change only causes the assigned IP from docker to be used to listen on instead of localhost for all services they should all be able to communicate using this IP.
